### PR TITLE
Split out main Cabinet interface and CabinetBase ABC class

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,13 @@ care of any required initial setup.
 ```python
 from cabinets.cabinet import Cabinets, S3Cabinet
 
-S3Cabinet.set_configuration(region_name='us-west-2')
+# set the AWS S3 region to us-west-2 and specify an access key
+S3Cabinet.set_configuration(region_name='us-west-2', aws_access_key_id=...)
 
-S3Cabinet.read('bucket-us-west-2/test.json')
-# or
+# use specific Cabinet to avoid protocol prefix
+S3Cabinet.read('bucket-in-us-west-2/test.json') 
+# or use generic Cabinet with protocol prefix
 Cabinets.read('s3://bucket-us-west-2/test.json')
 ```
 
+See the documentation of specific `Cabinet` classes for what configuration parameters are available.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ with open('data.json', 'w') as fh:
 Read back and parse the file using `cabinets`:
 
 ```python
-from cabinets import Cabinet
+from cabinets import CabinetBase
 
-new_obj = Cabinet.read('file://test.json')
+new_obj = CabinetBase.read('file://test.json')
 
 assert new_obj == obj
 ```
@@ -40,13 +40,13 @@ That's it! The file is *loaded* and *parsed* in just one line.
 only `cabinets`.
 
 ```python
-from cabinets import Cabinet
+from cabinets import CabinetBase
 
 obj = {'test': 1}
 
-Cabinet.create('file://test.json', obj)
+CabinetBase.create('file://test.json', obj)
 
-new_obj = Cabinet.read('file://test.json')
+new_obj = CabinetBase.read('file://test.json')
 
 assert new_obj == obj
 ```
@@ -97,13 +97,13 @@ class FooParser(Parser):
 Then to load a `test.foo` file you can simply use `Cabinet.read`
 
 ```python
-from cabinets import Cabinet
+from cabinets import CabinetBase
 
 # .foo file in local filesystem
-local_foo_data = Cabinet.read('file://test.foo')
+local_foo_data = CabinetBase.read('file://test.foo')
 
 # .foo file in S3
-s3_foo_data = Cabinet.read('s3://test.foo')
+s3_foo_data = CabinetBase.read('s3://test.foo')
 ```
 
 
@@ -114,13 +114,13 @@ Each `Cabinet` subclass can expose a `set_configuration(**config)` classmethod t
 care of any required initial setup.
 
 ```python
-from cabinets.cabinet import Cabinet, S3Cabinet
+from cabinets.cabinet import CabinetBase, S3Cabinet
 
 S3Cabinet.set_configuration(region_name='us-west-2')
 
 S3Cabinet.read('bucket-us-west-2/test.json')
 # or
-Cabinet.read('s3://bucket-us-west-2/test.json')
+CabinetBase.read('s3://bucket-us-west-2/test.json')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Each `Cabinet` subclass can expose a `set_configuration(**config)` classmethod t
 care of any required initial setup.
 
 ```python
-from cabinets.cabinet import Cabinets, S3Cabinet
+from cabinets.protocols.s3 import S3Cabinet
 
 # set the AWS S3 region to us-west-2 and specify an access key
 S3Cabinet.set_configuration(region_name='us-west-2', aws_access_key_id=...)
@@ -122,6 +122,7 @@ S3Cabinet.set_configuration(region_name='us-west-2', aws_access_key_id=...)
 # use specific Cabinet to avoid protocol prefix
 S3Cabinet.read('bucket-in-us-west-2/test.json') 
 # or use generic Cabinet with protocol prefix
+from cabinets.cabinet import Cabinets
 Cabinets.read('s3://bucket-us-west-2/test.json')
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,5 @@ S3Cabinet.set_configuration(region_name='us-west-2')
 S3Cabinet.read('bucket-us-west-2/test.json')
 # or
 Cabinets.read('s3://bucket-us-west-2/test.json')
-
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ with open('data.json', 'w') as fh:
 Read back and parse the file using `cabinets`:
 
 ```python
-from cabinets import CabinetInterface
+from cabinets import Cabinets
 
-new_obj = CabinetInterface.read('file://test.json')
+new_obj = Cabinets.read('file://test.json')
 
 assert new_obj == obj
 ```
@@ -40,13 +40,13 @@ That's it! The file is *loaded* and *parsed* in just one line.
 only `cabinets`.
 
 ```python
-from cabinets import CabinetInterface
+from cabinets import Cabinets
 
 obj = {'test': 1}
 
-CabinetInterface.create('file://test.json', obj)
+Cabinets.create('file://test.json', obj)
 
-new_obj = CabinetInterface.read('file://test.json')
+new_obj = Cabinets.read('file://test.json')
 
 assert new_obj == obj
 ```
@@ -97,13 +97,13 @@ class FooParser(Parser):
 Then to load a `test.foo` file you can simply use `Cabinet.read`
 
 ```python
-from cabinets import CabinetInterface
+from cabinets import Cabinets
 
 # .foo file in local filesystem
-local_foo_data = CabinetInterface.read('file://test.foo')
+local_foo_data = Cabinets.read('file://test.foo')
 
 # .foo file in S3
-s3_foo_data = CabinetInterface.read('s3://test.foo')
+s3_foo_data = Cabinets.read('s3://test.foo')
 ```
 
 
@@ -114,13 +114,13 @@ Each `Cabinet` subclass can expose a `set_configuration(**config)` classmethod t
 care of any required initial setup.
 
 ```python
-from cabinets.cabinet import CabinetInterface, S3Cabinet
+from cabinets.cabinet import Cabinets, S3Cabinet
 
 S3Cabinet.set_configuration(region_name='us-west-2')
 
 S3Cabinet.read('bucket-us-west-2/test.json')
 # or
-CabinetInterface.read('s3://bucket-us-west-2/test.json')
+Cabinets.read('s3://bucket-us-west-2/test.json')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ class FooParser(Parser):
 
 ```
 
-Then to load a `test.foo` file you can simply use `Cabinet.read`
+Then to load a `test.foo` file you can simply use `Cabinet.read`. 
+
+> **NOTE**: In order for the extension to be registered, the class definition must be
+> run at least once. Make sure the modules where your custom `Parser` classes are defined
+> are imported somewhere before they are used.
 
 ```python
 from cabinets import Cabinets

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ with open('data.json', 'w') as fh:
 Read back and parse the file using `cabinets`:
 
 ```python
-from cabinets import CabinetBase
+from cabinets import CabinetInterface
 
-new_obj = CabinetBase.read('file://test.json')
+new_obj = CabinetInterface.read('file://test.json')
 
 assert new_obj == obj
 ```
@@ -40,13 +40,13 @@ That's it! The file is *loaded* and *parsed* in just one line.
 only `cabinets`.
 
 ```python
-from cabinets import CabinetBase
+from cabinets import CabinetInterface
 
 obj = {'test': 1}
 
-CabinetBase.create('file://test.json', obj)
+CabinetInterface.create('file://test.json', obj)
 
-new_obj = CabinetBase.read('file://test.json')
+new_obj = CabinetInterface.read('file://test.json')
 
 assert new_obj == obj
 ```
@@ -97,13 +97,13 @@ class FooParser(Parser):
 Then to load a `test.foo` file you can simply use `Cabinet.read`
 
 ```python
-from cabinets import CabinetBase
+from cabinets import CabinetInterface
 
 # .foo file in local filesystem
-local_foo_data = CabinetBase.read('file://test.foo')
+local_foo_data = CabinetInterface.read('file://test.foo')
 
 # .foo file in S3
-s3_foo_data = CabinetBase.read('s3://test.foo')
+s3_foo_data = CabinetInterface.read('s3://test.foo')
 ```
 
 
@@ -114,13 +114,13 @@ Each `Cabinet` subclass can expose a `set_configuration(**config)` classmethod t
 care of any required initial setup.
 
 ```python
-from cabinets.cabinet import CabinetBase, S3Cabinet
+from cabinets.cabinet import CabinetInterface, S3Cabinet
 
 S3Cabinet.set_configuration(region_name='us-west-2')
 
 S3Cabinet.read('bucket-us-west-2/test.json')
 # or
-CabinetBase.read('s3://bucket-us-west-2/test.json')
+CabinetInterface.read('s3://bucket-us-west-2/test.json')
 
 ```
 

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,3 +1,3 @@
-from .cabinet import CabinetBase
+from .cabinet import CabinetInterface
 
-__all__ = (CabinetBase,)
+__all__ = (CabinetInterface,)

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,3 +1,3 @@
-from .cabinet import Cabinet
+from .cabinet import CabinetBase
 
-__all__ = (Cabinet,)
+__all__ = (CabinetBase,)

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,3 +1,5 @@
-from .cabinet import Cabinets
+from cabinets.cabinet import Cabinets
+from cabinets.protocols.file import FileCabinet
+from cabinets.protocols.s3 import S3Cabinet
 
 __all__ = (Cabinets,)

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,3 +1,3 @@
-from .cabinet import CabinetInterface
+from .cabinet import Cabinets
 
-__all__ = (CabinetInterface,)
+__all__ = (Cabinets,)

--- a/cabinets/cabinet.py
+++ b/cabinets/cabinet.py
@@ -1,9 +1,4 @@
-import os
 from abc import ABC, abstractmethod
-
-import boto3
-
-from cabinets.logger import error, info
 from cabinets.parser import Parser
 
 _SUPPORTED_PROTOCOLS = {}
@@ -59,78 +54,6 @@ class CabinetBase(ABC):
         pass
 
 
-@register_protocols('s3')
-class S3Cabinet(CabinetBase):
-    client = None
-
-    @classmethod
-    def set_configuration(cls, region_name='us-east-1', aws_access_key_id=None,
-                          aws_secret_access_key=None, aws_session_token=None):
-        cls.client = boto3.client('s3', region_name=region_name,
-                                  aws_access_key_id=aws_access_key_id,
-                                  aws_secret_access_key=aws_secret_access_key,
-                                  aws_session_token=aws_session_token)
-
-    @classmethod
-    def _read_content(cls, path) -> bytes:
-        bucket, *key = path.split('/')
-        if not key:
-            raise ValueError('S3 path needs bucket')
-        key = '/'.join(key)
-        info(f'Downloading {key} from Bucket {bucket}')
-        try:
-            resp = cls.client.get_object(Bucket=bucket, Key=key)
-            return resp.get('Body').read()
-        except Exception as ex:
-            error(f"Cannot download {path} from S3 Bucket '{bucket}': {ex}")
-            raise ex
-
-    @classmethod
-    def _create_content(cls, path, content):
-        bucket, *key = path.split('/')
-        key = '/'.join(key)
-        info(f"Uploading {key} to {bucket}")
-        try:
-            cls.client.put_object(Bucket=bucket, Key=key, Body=content)
-            return True
-        except Exception as ex:
-            error(f"Cannot upload {path} to S3 Bucket '{bucket}': {ex}")
-            return False
-
-    @classmethod
-    def _delete_content(cls, path):
-        bucket, *key = path.split('/')
-        key = '/'.join(key)
-        info(f"Uploading {key} to {bucket}")
-        try:
-            cls.client.delete_object(Bucket=bucket, Key=key)
-            return True
-        except Exception as ex:
-            error(f"Cannot delete {path} from S3 Bucket '{bucket}': {ex}")
-            return False
-
-
-@register_protocols('file')
-class FileCabinet(CabinetBase):
-    @classmethod
-    def _read_content(cls, path) -> bytes:
-        # TODO: Investigate if binary read mode is always okay
-        with open(os.path.normpath(path), 'rb') as file:
-            return file.read()
-
-    @classmethod
-    def _create_content(cls, path, content):
-        dirs = os.path.dirname(os.path.normpath(path))
-        if dirs:
-            os.makedirs(dirs, exist_ok=True)
-        mode = 'w' if isinstance(content, str) else 'wb'
-        with open(os.path.normpath(path), mode) as file:
-            file.write(content)
-
-    @classmethod
-    def _delete_content(cls, path):
-        os.remove(os.path.normpath(path))
-
 
 class Cabinets:
 
@@ -138,6 +61,8 @@ class Cabinets:
     def from_uri(cls, uri) -> (CabinetBase, str):
         protocol, path = uri.split('://')
         cabinet = _SUPPORTED_PROTOCOLS.get(protocol)
+        if not cabinet:
+            raise KeyError(f'Could not find Cabinet for protocol key \'{protocol}\'')
         return cabinet, path
 
     @classmethod

--- a/cabinets/cabinet.py
+++ b/cabinets/cabinet.py
@@ -148,7 +148,7 @@ class Cabinets:
     @classmethod
     def create(cls, uri, content, raw=False):
         cabinet, path = cls.from_uri(uri)
-        return cabinet.read(path, content, raw=raw)
+        return cabinet.create(path, content, raw=raw)
 
     @classmethod
     def delete(cls, uri):

--- a/cabinets/cabinet.py
+++ b/cabinets/cabinet.py
@@ -27,7 +27,7 @@ class Cabinet:
         return cabinet, path
 
     @classmethod
-    def read(cls, uri, raw=False) -> bytes:
+    def read(cls, uri, raw=False):
         cabinet, path = cls.from_uri(uri)
         return cabinet.read(path, raw=raw)
 
@@ -50,7 +50,7 @@ class CabinetBase(ABC):
         pass
 
     @classmethod
-    def read(cls, path, raw=False) -> bytes:
+    def read(cls, path, raw=False):
         if raw:
             return cls._read_content(path)
         else:

--- a/cabinets/cabinet.py
+++ b/cabinets/cabinet.py
@@ -10,7 +10,7 @@ _SUPPORTED_PROTOCOLS = {}
 
 
 def register_protocols(*protocols):
-    def decorate_cabinet(cabinet: CabinetBase):
+    def decorate_cabinet(cabinet: CabinetInterface):
         for protocol in protocols:
             _SUPPORTED_PROTOCOLS[protocol] = cabinet
         return cabinet
@@ -42,7 +42,7 @@ class Cabinet:
         return cabinet.delete(path)
 
 
-class CabinetBase(ABC):
+class CabinetInterface(ABC):
 
     @classmethod
     @abstractmethod
@@ -84,7 +84,7 @@ class CabinetBase(ABC):
 
 
 @register_protocols('s3')
-class S3Cabinet(CabinetBase):
+class S3Cabinet(CabinetInterface):
     client = None
 
     @classmethod
@@ -135,7 +135,7 @@ class S3Cabinet(CabinetBase):
 
 
 @register_protocols('file')
-class FileCabinet(CabinetBase):
+class FileCabinet(CabinetInterface):
     @classmethod
     def _read_content(cls, path) -> bytes:
         # TODO: Investigate if binary read mode is always okay

--- a/cabinets/protocols/file.py
+++ b/cabinets/protocols/file.py
@@ -1,0 +1,25 @@
+import os
+
+from cabinets.cabinet import register_protocols, CabinetBase
+
+
+@register_protocols('file')
+class FileCabinet(CabinetBase):
+    @classmethod
+    def _read_content(cls, path) -> bytes:
+        # TODO: Investigate if binary read mode is always okay
+        with open(os.path.normpath(path), 'rb') as file:
+            return file.read()
+
+    @classmethod
+    def _create_content(cls, path, content):
+        dirs = os.path.dirname(os.path.normpath(path))
+        if dirs:
+            os.makedirs(dirs, exist_ok=True)
+        mode = 'w' if isinstance(content, str) else 'wb'
+        with open(os.path.normpath(path), mode) as file:
+            file.write(content)
+
+    @classmethod
+    def _delete_content(cls, path):
+        os.remove(os.path.normpath(path))

--- a/cabinets/protocols/s3.py
+++ b/cabinets/protocols/s3.py
@@ -1,0 +1,55 @@
+import boto3
+
+from cabinets.cabinet import register_protocols, CabinetBase
+from cabinets.logger import info, error
+
+
+@register_protocols('s3')
+class S3Cabinet(CabinetBase):
+    client = None
+
+    @classmethod
+    def set_configuration(cls, region_name='us-east-1', aws_access_key_id=None,
+                          aws_secret_access_key=None, aws_session_token=None):
+        cls.client = boto3.client('s3', region_name=region_name,
+                                  aws_access_key_id=aws_access_key_id,
+                                  aws_secret_access_key=aws_secret_access_key,
+                                  aws_session_token=aws_session_token)
+
+    @classmethod
+    def _read_content(cls, path) -> bytes:
+        bucket, *key = path.split('/')
+        if not key:
+            raise ValueError('S3 path needs bucket')
+        key = '/'.join(key)
+        info(f'Downloading {key} from Bucket {bucket}')
+        try:
+            resp = cls.client.get_object(Bucket=bucket, Key=key)
+            return resp.get('Body').read()
+        except Exception as ex:
+            error(f"Cannot download {path} from S3 Bucket '{bucket}': {ex}")
+            raise ex
+
+    @classmethod
+    def _create_content(cls, path, content):
+        bucket, *key = path.split('/')
+        key = '/'.join(key)
+        info(f"Uploading {key} to {bucket}")
+        try:
+            cls.client.put_object(Bucket=bucket, Key=key, Body=content)
+            return True
+        except Exception as ex:
+            error(f"Cannot upload {path} to S3 Bucket '{bucket}': {ex}")
+            return False
+
+    @classmethod
+    def _delete_content(cls, path):
+        bucket, *key = path.split('/')
+        key = '/'.join(key)
+        info(f"Uploading {key} to {bucket}")
+        try:
+            cls.client.delete_object(Bucket=bucket, Key=key)
+            return True
+        except Exception as ex:
+            error(f"Cannot delete {path} from S3 Bucket '{bucket}': {ex}")
+            return False

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import boto3
 
-from cabinets.cabinet import Cabinet, S3Cabinet
+from cabinets.cabinet import Cabinets, S3Cabinet
 from moto import mock_s3
 from pyfakefs import fake_filesystem_unittest
 
@@ -20,12 +20,12 @@ class TestFileSystemCabinet(fake_filesystem_unittest.TestCase):
     def test_read_json(self):
         protocol = 'file'
         filename = os.path.join(self.fixture_path, 'sample.json')
-        data = Cabinet.read(f'{protocol}://{filename}')
+        data = Cabinets.read(f'{protocol}://{filename}')
         self.assertEqual({'hello': 'world'}, data)
 
     def test_create_json(self):
         protocol, filename = 'file', 'tmp/sample.json'
-        Cabinet.create(f'{protocol}://{filename}', {'hello': 'world'})
+        Cabinets.create(f'{protocol}://{filename}', {'hello': 'world'})
         with open(filename) as fh:
             data = json.load(fh)
         self.assertEqual({'hello': 'world'}, data)
@@ -36,30 +36,30 @@ class TestFileSystemCabinet(fake_filesystem_unittest.TestCase):
         with open(filename, 'w') as fh:
             json.dump(data, fh)
         self.assertTrue(os.path.isfile(filename))
-        Cabinet.delete(f'{protocol}://{filename}')
+        Cabinets.delete(f'{protocol}://{filename}')
         self.assertFalse(os.path.isfile(filename))
 
     def test_read_create_json(self):
         protocol, filename = 'file', 'test.json'
         data = {'I': {'am': ['nested', 1, 'object', None]}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
+        Cabinets.create(f'{protocol}://{filename}', data)
+        Cabinets.create(f'{protocol}://{filename}', data)
+        result = Cabinets.read(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
 
     def test_read_create_yaml(self):
         protocol, filename = 'file', 'test.yml'
         data = {'I': {'am': ['nested', 1, 'object', None]}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
+        Cabinets.create(f'{protocol}://{filename}', data)
+        result = Cabinets.read(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
 
     def test_read_create_pickle(self):
         protocol, filename = 'file', 'test.pickle'
         data = {'I': {'am': ['nested', 1 + 2j, 'object', None],
                       'purple': SimpleNamespace(egg=True, fish=42)}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
+        Cabinets.create(f'{protocol}://{filename}', data)
+        result = Cabinets.read(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
 
 
@@ -79,9 +79,9 @@ class TestS3Cabinet(unittest.TestCase):
         client.create_bucket(Bucket=bucket)
         protocol, filename = 's3', f'{bucket}/test.yml'
         data = {'I': {'am': ['nested', 1, 'object', None]}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
-        Cabinet.delete(f'{protocol}://{filename}')
+        Cabinets.create(f'{protocol}://{filename}', data)
+        result = Cabinets.read(f'{protocol}://{filename}')
+        Cabinets.delete(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
         client.delete_bucket(Bucket=bucket)
 

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import boto3
 
-from cabinets.cabinet import Cabinet, S3Cabinet
+from cabinets.cabinet import CabinetBase, S3Cabinet
 from moto import mock_s3
 from pyfakefs import fake_filesystem_unittest
 
@@ -20,12 +20,12 @@ class TestFileSystemCabinet(fake_filesystem_unittest.TestCase):
     def test_read_json(self):
         protocol = 'file'
         filename = os.path.join(self.fixture_path, 'sample.json')
-        data = Cabinet.read(f'{protocol}://{filename}')
+        data = CabinetBase.read(f'{protocol}://{filename}')
         self.assertEqual({'hello': 'world'}, data)
 
     def test_create_json(self):
         protocol, filename = 'file', 'tmp/sample.json'
-        Cabinet.create(f'{protocol}://{filename}', {'hello': 'world'})
+        CabinetBase.create(f'{protocol}://{filename}', {'hello': 'world'})
         with open(filename) as fh:
             data = json.load(fh)
         self.assertEqual({'hello': 'world'}, data)
@@ -36,29 +36,29 @@ class TestFileSystemCabinet(fake_filesystem_unittest.TestCase):
         with open(filename, 'w') as fh:
             json.dump(data, fh)
         self.assertTrue(os.path.isfile(filename))
-        Cabinet.delete(f'{protocol}://{filename}')
+        CabinetBase.delete(f'{protocol}://{filename}')
         self.assertFalse(os.path.isfile(filename))
 
     def test_read_create_json(self):
         protocol, filename = 'file', 'test.json'
         data = {'I': {'am': ['nested', 1, 'object', None]}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
+        CabinetBase.create(f'{protocol}://{filename}', data)
+        result = CabinetBase.read(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
 
     def test_read_create_yaml(self):
         protocol, filename = 'file', 'test.yml'
         data = {'I': {'am': ['nested', 1, 'object', None]}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
+        CabinetBase.create(f'{protocol}://{filename}', data)
+        result = CabinetBase.read(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
 
     def test_read_create_pickle(self):
         protocol, filename = 'file', 'test.pickle'
         data = {'I': {'am': ['nested', 1 + 2j, 'object', None],
                       'purple': SimpleNamespace(egg=True, fish=42)}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
+        CabinetBase.create(f'{protocol}://{filename}', data)
+        result = CabinetBase.read(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
 
 
@@ -78,9 +78,9 @@ class TestS3Cabinet(unittest.TestCase):
         client.create_bucket(Bucket=bucket)
         protocol, filename = 's3', f'{bucket}/test.yml'
         data = {'I': {'am': ['nested', 1, 'object', None]}}
-        Cabinet.create(f'{protocol}://{filename}', data)
-        result = Cabinet.read(f'{protocol}://{filename}')
-        Cabinet.delete(f'{protocol}://{filename}')
+        CabinetBase.create(f'{protocol}://{filename}', data)
+        result = CabinetBase.read(f'{protocol}://{filename}')
+        CabinetBase.delete(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
         client.delete_bucket(Bucket=bucket)
 


### PR DESCRIPTION
* Add a new highest level interface class and rename old abstract base class to `CabinetBase`. 

Allows for direct CRUD operations with a path on a specific Cabinet.