### PR TITLE
Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,28 +29,24 @@ with open('data.json', 'w') as fh:
 Read back and parse the file using `cabinets`:
 
 ```python
-from cabinets import Cabinets
+import cabinets
 
-new_obj = Cabinets.read('file://test.json')
-
-assert new_obj == obj
+new_obj = cabinets.read('file://test.json')
 ```
 
 That's it! The file is *loaded* and *parsed* in just one line.
 
 ### Write a file
 
-`Cabinet` also supports creating files. We can rewrite the first example using
-only `cabinets`.
+`cabinets` also supports creating files. We can rewrite the first example using only `cabinets`.
 
 ```python
-from cabinets import Cabinets
+import cabinets
 
 obj = {'test': 1}
+cabinets.create('file://test.json', obj)
 
-Cabinets.create('file://test.json', obj)
-
-new_obj = Cabinets.read('file://test.json')
+new_obj = cabinets.read('file://test.json')
 
 assert new_obj == obj
 ```
@@ -95,7 +91,6 @@ class FooParser(Parser):
     @classmethod
     def _dump_content(cls, data: Any) -> bytes:
         return serialize_foo(data)  # custom serialization logic
-
 ```
 
 Then to load a `test.foo` file you can simply use `Cabinet.read`. 
@@ -105,15 +100,14 @@ Then to load a `test.foo` file you can simply use `Cabinet.read`.
 > are imported somewhere before they are used.
 
 ```python
-from cabinets import Cabinets
+import cabinets
 
 # .foo file in local filesystem
-local_foo_data = Cabinets.read('file://test.foo')
+local_foo_data = cabinets.read('file://test.foo')
 
 # .foo file in S3
-s3_foo_data = Cabinets.read('s3://test.foo')
+s3_foo_data = cabinets.read('s3://test.foo')
 ```
-
 
 ## Protocol Configuration
 
@@ -130,8 +124,8 @@ S3Cabinet.set_configuration(region_name='us-west-2', aws_access_key_id=...)
 # use specific Cabinet to avoid protocol prefix
 S3Cabinet.read('bucket-in-us-west-2/test.json') 
 # or use generic Cabinet with protocol prefix
-from cabinets import Cabinets
-Cabinets.read('s3://bucket-us-west-2/test.json')
+import cabinets
+cabinets.read('s3://bucket-us-west-2/test.json')
 ```
 
 See the documentation of specific `Cabinet` classes for what configuration parameters are available.

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,44 +1,49 @@
 import os
 
 from cabinets import plugins
-from cabinets.cabinet import CabinetBase, SUPPORTED_PROTOCOLS
+from cabinets.cabinet import (
+    Cabinet,
+    CabinetError,
+    register_protocols,
+    SUPPORTED_PROTOCOLS,
+)
+from cabinets.parser import (
+    Parser,
+    register_extensions,
+    SUPPORTED_EXTENSIONS,
+)
 
-
-plugins.discover_built_in('cabinet')
-plugins.discover_built_in('parser')
-
-PLUGIN_PATHS = os.environ.get('PLUGIN_PATHS')
-if PLUGIN_PATHS:
-    plugins.discover_custom(*PLUGIN_PATHS.split(','))
+PLUGIN_PATH = os.environ.get('PLUGIN_PATH')
+plugins.discover_all(custom_plugin_path=PLUGIN_PATH)
 
 
 class InvalidURIError(Exception):
     pass
 
 
-def from_uri(uri) -> (CabinetBase, str):
+def from_uri(uri) -> (Cabinet, str):
     try:
         protocol, path = uri.split('://')
     except ValueError:
         raise InvalidURIError("Missing protocol identifier")
-    cabinet = SUPPORTED_PROTOCOLS.get(protocol)
-    if not cabinet:
+    cabinet_ = SUPPORTED_PROTOCOLS.get(protocol)
+    if not cabinet_:
         raise InvalidURIError(f"Unknown protocol '{protocol}'")
     if not path:
         raise InvalidURIError("Empty resource path")
-    return cabinet, path
+    return cabinet_, path
 
 
 def read(uri, raw=False):
-    cabinet, path = from_uri(uri)
-    return cabinet.read(path, raw=raw)
+    cabinet_, path = from_uri(uri)
+    return cabinet_.read(path, raw=raw)
 
 
 def create(uri, content, raw=False):
-    cabinet, path = from_uri(uri)
-    return cabinet.create(path, content, raw=raw)
+    cabinet_, path = from_uri(uri)
+    return cabinet_.create(path, content, raw=raw)
 
 
 def delete(uri):
-    cabinet, path = from_uri(uri)
-    return cabinet.delete(path)
+    cabinet_, path = from_uri(uri)
+    return cabinet_.delete(path)

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -23,7 +23,8 @@ __all__ = [
     SUPPORTED_EXTENSIONS,
 ]
 
-PLUGIN_PATH = os.environ.get('PLUGIN_PATH')
+PLUGIN_PATH = os.environ.get('PLUGIN_PATH',
+                             os.path.join(os.getcwd(), 'cabinets'))
 plugins.discover_all(custom_plugin_path=PLUGIN_PATH)
 
 

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,10 +1,20 @@
+import importlib
+import os
+import pkgutil
+
 from cabinets.cabinet import CabinetBase, SUPPORTED_PROTOCOLS
-from cabinets.cabinet.file import FileCabinet  # noqa: F401
-from cabinets.cabinet.s3 import S3Cabinet  # noqa: F401
-from cabinets.parser.pickle import PickleParser  # noqa: F401
-from cabinets.parser.json import JSONParser  # noqa: F401
-from cabinets.parser.yaml import YAMLParser  # noqa: F401
-from cabinets.parser.csv import CSVParser  # noqa: F401
+
+
+def load_plugins(plugin_dir):
+    path = os.path.join(os.path.dirname(__file__), plugin_dir)
+    pkgs = pkgutil.iter_modules((path,))
+    for plugin in pkgs:
+        pkg = '.'.join((__package__, plugin_dir, plugin.name))
+        importlib.import_module(pkg)
+
+
+load_plugins('cabinet')
+load_plugins('parser')
 
 
 class InvalidURIError(Exception):

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -23,8 +23,9 @@ __all__ = [
     SUPPORTED_EXTENSIONS,
 ]
 
-PLUGIN_PATH = os.environ.get('PLUGIN_PATH',
-                             os.path.join(os.getcwd(), 'cabinets'))
+PLUGIN_PATH = os.environ.get('PLUGIN_PATH', os.path.join(os.getcwd(), 'cabinets'))
+if PLUGIN_PATH == os.path.dirname(__file__):
+    PLUGIN_PATH = None
 plugins.discover_all(custom_plugin_path=PLUGIN_PATH)
 
 

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -13,6 +13,16 @@ from cabinets.parser import (
     SUPPORTED_EXTENSIONS,
 )
 
+__all__ = [
+    Cabinet,
+    CabinetError,
+    Parser,
+    register_protocols,
+    register_extensions,
+    SUPPORTED_PROTOCOLS,
+    SUPPORTED_EXTENSIONS,
+]
+
 PLUGIN_PATH = os.environ.get('PLUGIN_PATH')
 plugins.discover_all(custom_plugin_path=PLUGIN_PATH)
 

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,52 +1,44 @@
-import importlib
 import os
-import pkgutil
 
+from cabinets import plugins
 from cabinets.cabinet import CabinetBase, SUPPORTED_PROTOCOLS
 
 
-def load_plugins(plugin_dir):
-    path = os.path.join(os.path.dirname(__file__), plugin_dir)
-    pkgs = pkgutil.iter_modules((path,))
-    for plugin in pkgs:
-        pkg = '.'.join((__package__, plugin_dir, plugin.name))
-        importlib.import_module(pkg)
+plugins.discover_built_in('cabinet')
+plugins.discover_built_in('parser')
 
-
-load_plugins('cabinet')
-load_plugins('parser')
+PLUGIN_PATHS = os.environ.get('PLUGIN_PATHS')
+if PLUGIN_PATHS:
+    plugins.discover_custom(*PLUGIN_PATHS.split(','))
 
 
 class InvalidURIError(Exception):
     pass
 
 
-class Cabinets:
+def from_uri(uri) -> (CabinetBase, str):
+    try:
+        protocol, path = uri.split('://')
+    except ValueError:
+        raise InvalidURIError("Missing protocol identifier")
+    cabinet = SUPPORTED_PROTOCOLS.get(protocol)
+    if not cabinet:
+        raise InvalidURIError(f"Unknown protocol '{protocol}'")
+    if not path:
+        raise InvalidURIError("Empty resource path")
+    return cabinet, path
 
-    @classmethod
-    def from_uri(cls, uri) -> (CabinetBase, str):
-        try:
-            protocol, path = uri.split('://')
-        except ValueError:
-            raise InvalidURIError("Missing protocol identifier")
-        cabinet = SUPPORTED_PROTOCOLS.get(protocol)
-        if not cabinet:
-            raise InvalidURIError(f"Unknown protocol '{protocol}'")
-        if not path:
-            raise InvalidURIError("Empty resource path")
-        return cabinet, path
 
-    @classmethod
-    def read(cls, uri, raw=False):
-        cabinet, path = cls.from_uri(uri)
-        return cabinet.read(path, raw=raw)
+def read(uri, raw=False):
+    cabinet, path = from_uri(uri)
+    return cabinet.read(path, raw=raw)
 
-    @classmethod
-    def create(cls, uri, content, raw=False):
-        cabinet, path = cls.from_uri(uri)
-        return cabinet.create(path, content, raw=raw)
 
-    @classmethod
-    def delete(cls, uri):
-        cabinet, path = cls.from_uri(uri)
-        return cabinet.delete(path)
+def create(uri, content, raw=False):
+    cabinet, path = from_uri(uri)
+    return cabinet.create(path, content, raw=raw)
+
+
+def delete(uri):
+    cabinet, path = from_uri(uri)
+    return cabinet.delete(path)

--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -12,10 +12,10 @@ class CabinetError(Exception):
 def register_protocols(*protocols):
     def decorate_cabinet(cabinet):
         try:
-            if not issubclass(cabinet, CabinetBase):
+            if not issubclass(cabinet, Cabinet):
                 raise CabinetError(f"Cannot register protocol: Type "
                                    f"'{cabinet.__name__}' is not a subclass of "
-                                   f"'{CabinetBase.__name__}'")
+                                   f"'{Cabinet.__name__}'")
         except TypeError:
             raise CabinetError(
                 "Cannot register protocol: Decorated object must be a class")
@@ -29,7 +29,7 @@ def register_protocols(*protocols):
     return decorate_cabinet
 
 
-class CabinetBase(ABC):
+class Cabinet(ABC):
 
     @classmethod
     @abstractmethod

--- a/cabinets/cabinet/file.py
+++ b/cabinets/cabinet/file.py
@@ -1,10 +1,10 @@
 import os
 
-from cabinets.cabinet import register_protocols, CabinetBase
+from cabinets.cabinet import register_protocols, Cabinet
 
 
 @register_protocols('file')
-class FileCabinet(CabinetBase):
+class FileCabinet(Cabinet):
     @classmethod
     def _read_content(cls, path) -> bytes:
         # TODO: Investigate if binary read mode is always okay

--- a/cabinets/cabinet/s3.py
+++ b/cabinets/cabinet/s3.py
@@ -1,11 +1,11 @@
 import boto3
 
-from cabinets.cabinet import register_protocols, CabinetBase
+from cabinets.cabinet import register_protocols, Cabinet
 from cabinets.logger import info, error
 
 
 @register_protocols('s3')
-class S3Cabinet(CabinetBase):
+class S3Cabinet(Cabinet):
     client = None
 
     @classmethod

--- a/cabinets/parser/__init__.py
+++ b/cabinets/parser/__init__.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-SUPPORTED_FILE_TYPES = {}
+SUPPORTED_EXTENSIONS = {}
 
 
 def register_extensions(*file_types):
     def decorate_parser(parser: Parser):
         for file_type in file_types:
-            SUPPORTED_FILE_TYPES[file_type] = parser
+            SUPPORTED_EXTENSIONS[file_type] = parser
         return parser
 
     return decorate_parser
@@ -18,7 +18,7 @@ class Parser(ABC):
     @classmethod
     def load(cls, path, content: bytes):
         filepath, ext = path.split('.')
-        return SUPPORTED_FILE_TYPES[ext].load_content(content)
+        return SUPPORTED_EXTENSIONS[ext].load_content(content)
 
     @classmethod
     @abstractmethod
@@ -28,7 +28,7 @@ class Parser(ABC):
     @classmethod
     def dump(cls, path, data: Any):
         filepath, ext = path.split('.')
-        return SUPPORTED_FILE_TYPES[ext].dump_content(data)
+        return SUPPORTED_EXTENSIONS[ext].dump_content(data)
 
     @classmethod
     @abstractmethod

--- a/cabinets/plugins.py
+++ b/cabinets/plugins.py
@@ -13,7 +13,7 @@ def discover_built_in(plugin_path):
     for plugin in plugins:
         pkg = '.'.join((__package__, plugin_path, plugin.name))
         importlib.import_module(pkg)
-        info(f"Loaded custom plugin '{plugin.name}'")
+        info(f"Loaded built-in plugin '{plugin.name}'")
 
 
 def discover_custom(*paths):

--- a/cabinets/plugins.py
+++ b/cabinets/plugins.py
@@ -9,18 +9,18 @@ import cabinets.parser
 from cabinets.logger import info
 
 
-def discover(path, prefix):
-    plugins = pkgutil.iter_modules(path, prefix + '.')
+def discover(path, prefix=''):
+    plugins = pkgutil.iter_modules(path, prefix)
     for _, name, _ in plugins:
         importlib.import_module(name)
         info(f"Loaded plugin '{name}'")
 
 
 def discover_all(custom_plugin_path=None):
-    discover(cabinets.cabinet.__path__, prefix=cabinets.cabinet.__name__)
-    discover(cabinets.parser.__path__, prefix=cabinets.parser.__name__)
+    discover(cabinets.cabinet.__path__, prefix=cabinets.cabinet.__name__ + '.')
+    discover(cabinets.parser.__path__, prefix=cabinets.parser.__name__ + '.')
     if custom_plugin_path:
-        sys.path.insert(1, custom_plugin_path)
         for pkg in ['cabinet', 'parser']:
             path = os.path.join(custom_plugin_path, pkg)
-            discover((path,), prefix=pkg)
+            sys.path.insert(1, path)
+            discover((path,))

--- a/cabinets/plugins.py
+++ b/cabinets/plugins.py
@@ -1,0 +1,23 @@
+import importlib
+import importlib.util
+import os
+import pkgutil
+
+from cabinets.logger import info
+
+
+def discover_built_in(plugin_path):
+    plugins = pkgutil.iter_modules((
+        os.path.join(os.path.dirname(__file__), plugin_path),
+    ))
+    for plugin in plugins:
+        pkg = '.'.join((__package__, plugin_path, plugin.name))
+        importlib.import_module(pkg)
+        info(f"Loaded custom plugin '{plugin.name}'")
+
+
+def discover_custom(*paths):
+    plugins = pkgutil.iter_modules(paths)
+    for plugin in plugins:
+        plugin.module_finder.find_module(plugin.name).load_module()
+        info(f"Loaded custom plugin '{plugin.name}'")

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -9,8 +9,8 @@ from pyfakefs import fake_filesystem_unittest
 
 import cabinets
 from cabinets import InvalidURIError
-from cabinets.cabinet import (
-    CabinetBase,
+from cabinets import (
+    Cabinet,
     CabinetError,
     register_protocols,
     SUPPORTED_PROTOCOLS,
@@ -124,7 +124,7 @@ class TestURI(unittest.TestCase):
             cabinets.from_uri(uri)
 
 
-class MockCabinet(CabinetBase):
+class MockCabinet(Cabinet):
     @classmethod
     def set_configuration(cls, **kwargs):
         return NotImplemented


### PR DESCRIPTION
- Auto detects built-in plugins
- Adds the ability to auto detect custom plugins (though the implementation isn't fabulous)
- Remove top level `Cabinets` class in favor of exposing directly off of the module

## Plugins
The Python Packaging Guide specifies a couple of options for [creating and discovering plugins](https://packaging.python.org/guides/creating-and-discovering-plugins/). In general the idea is to use `pkgutil` and `importlib` to dynamically load modules from a package. Basically we call [`pkgutil.iter_modules()`](https://docs.python.org/3/library/pkgutil.html#pkgutil.iter_modules) to detect plugins and [`importlib.import_module()`](https://docs.python.org/3/library/importlib.html#importlib.import_module) to load them. This works well for built-in plugins, but makes custom plugins challenging. Normally the best pattern is [using namespace packages](https://packaging.python.org/guides/creating-and-discovering-plugins/#using-namespace-packages) so that theoretically users just have to define the requisite package structure. However, I could not get this system to work with `cabinets` specified as a package explicitly (keeping `cabinets/__init__.py`).

### Update
The import hack from earlier has been replaced with actual import machinery. I've tried to keep the `plugins.discover()` function general, but it makes the syntax rather verbose. To get around it, I've also added a `plugins.discover_all()` that is meant to hide the complexity associated with discovery of both built-in and custom plugins 