### PR TITLE
Remove protection from cabinet _content methods

### DIFF
--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -40,32 +40,32 @@ class Cabinet(ABC):
     @classmethod
     def read(cls, path, raw=False):
         if raw:
-            return cls._read_content(path)
+            return cls.read_content(path)
         else:
-            return Parser.load(path, cls._read_content(path))
+            return Parser.load(path, cls.read_content(path))
 
     @classmethod
     def create(cls, path, content, raw=False):
         if raw:
-            return cls._create_content(path, content)
+            return cls.create_content(path, content)
         else:
-            return cls._create_content(path, Parser.dump(path, content))
+            return cls.create_content(path, Parser.dump(path, content))
 
     @classmethod
     def delete(cls, path):
-        cls._delete_content(path)
+        cls.delete_content(path)
 
     @classmethod
     @abstractmethod
-    def _read_content(cls, path) -> bytes:
+    def read_content(cls, path) -> bytes:
         pass  # pragma: no cover
 
     @classmethod
     @abstractmethod
-    def _create_content(cls, path, content):
+    def create_content(cls, path, content):
         pass  # pragma: no cover
 
     @classmethod
     @abstractmethod
-    def _delete_content(cls, path):
+    def delete_content(cls, path):
         pass  # pragma: no cover

--- a/cabinets/cabinet/file.py
+++ b/cabinets/cabinet/file.py
@@ -6,13 +6,13 @@ from cabinets.cabinet import register_protocols, Cabinet
 @register_protocols('file')
 class FileCabinet(Cabinet):
     @classmethod
-    def _read_content(cls, path) -> bytes:
+    def read_content(cls, path) -> bytes:
         # TODO: Investigate if binary read mode is always okay
         with open(os.path.normpath(path), 'rb') as file:
             return file.read()
 
     @classmethod
-    def _create_content(cls, path, content):
+    def create_content(cls, path, content):
         dirs = os.path.dirname(os.path.normpath(path))
         if dirs:
             os.makedirs(dirs, exist_ok=True)
@@ -21,5 +21,5 @@ class FileCabinet(Cabinet):
             file.write(content)
 
     @classmethod
-    def _delete_content(cls, path):
+    def delete_content(cls, path):
         os.remove(os.path.normpath(path))

--- a/cabinets/cabinet/s3.py
+++ b/cabinets/cabinet/s3.py
@@ -17,7 +17,7 @@ class S3Cabinet(Cabinet):
                                   aws_session_token=aws_session_token)
 
     @classmethod
-    def _read_content(cls, path) -> bytes:
+    def read_content(cls, path) -> bytes:
         bucket, *key = path.split('/')
         if not key:
             raise ValueError('S3 path needs bucket')
@@ -31,7 +31,7 @@ class S3Cabinet(Cabinet):
             raise ex
 
     @classmethod
-    def _create_content(cls, path, content):
+    def create_content(cls, path, content):
         bucket, *key = path.split('/')
         key = '/'.join(key)
         info(f"Uploading {key} to {bucket}")
@@ -43,7 +43,7 @@ class S3Cabinet(Cabinet):
             return False
 
     @classmethod
-    def _delete_content(cls, path):
+    def delete_content(cls, path):
         bucket, *key = path.split('/')
         key = '/'.join(key)
         info(f"Uploading {key} to {bucket}")

--- a/test/fixtures/plugins/cabinet/mock_cabinet.py
+++ b/test/fixtures/plugins/cabinet/mock_cabinet.py
@@ -9,13 +9,13 @@ class MockCabinet(Cabinet):
         return NotImplemented
 
     @classmethod
-    def _read_content(cls, path) -> bytes:
+    def read_content(cls, path) -> bytes:
         return NotImplemented
 
     @classmethod
-    def _create_content(cls, path, content):
+    def create_content(cls, path, content):
         return NotImplemented
 
     @classmethod
-    def _delete_content(cls, path):
+    def delete_content(cls, path):
         return NotImplemented

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -16,15 +16,15 @@ class MockCabinet(Cabinet):
         return NotImplemented
 
     @classmethod
-    def _read_content(cls, path) -> bytes:
+    def read_content(cls, path) -> bytes:
         return NotImplemented
 
     @classmethod
-    def _create_content(cls, path, content):
+    def create_content(cls, path, content):
         return NotImplemented
 
     @classmethod
-    def _delete_content(cls, path):
+    def delete_content(cls, path):
         return NotImplemented
 
 


### PR DESCRIPTION
Remove protection from `Cabinet` class methods, for parity with `Parser` class, and more logical subclass implementation.
* `Cabinet._read_content` -> `Cabinet.read_content`
* `Cabinet._write_content` -> `Cabinet.write_content`
* `Cabinet._delete_content`-> `Cabinet.delete_content`