### PR TITLE
Plain text parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+illustrator/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cabinets/parser/plain_text.py
+++ b/cabinets/parser/plain_text.py
@@ -6,8 +6,8 @@ class PlainTextParser(Parser):
 
     @classmethod
     def load_content(cls, content):
-        return content.decode()
+        return content.decode(encoding='utf-8')
 
     @classmethod
-    def dump_content(cls, data, encoding='utf-8'):
-        return bytes(data, encoding=encoding)
+    def dump_content(cls, data):
+        return bytes(data, encoding='utf-8')

--- a/cabinets/parser/txt.py
+++ b/cabinets/parser/txt.py
@@ -11,5 +11,5 @@ class PlainTextParser(Parser):
         return content.decode()
 
     @classmethod
-    def dump_content(cls, data):
-        return json.dumps(data)
+    def dump_content(cls, data, encoding='utf-8'):
+        return bytes(data, encoding=encoding)

--- a/cabinets/parser/txt.py
+++ b/cabinets/parser/txt.py
@@ -1,0 +1,15 @@
+import json
+
+from cabinets.parser import register_extensions, Parser
+
+
+@register_extensions('txt')
+class PlainTextParser(Parser):
+
+    @classmethod
+    def load_content(cls, content):
+        return content.decode()
+
+    @classmethod
+    def dump_content(cls, data):
+        return json.dumps(data)

--- a/cabinets/parser/txt.py
+++ b/cabinets/parser/txt.py
@@ -1,5 +1,3 @@
-import json
-
 from cabinets.parser import register_extensions, Parser
 
 

--- a/test/fixtures/sample.txt
+++ b/test/fixtures/sample.txt
@@ -2,4 +2,6 @@ I am sample text!
 This file has more than one line.
 Hey look, a panda.
 
+その鶏のサイズを見てください
 Now it's a new paragraph. This line has two sentences.
+🤯🦄

--- a/test/fixtures/sample.txt
+++ b/test/fixtures/sample.txt
@@ -1,0 +1,5 @@
+I am sample text!
+This file has more than one line.
+Hey look, a panda.
+
+Now it's a new paragraph. This line has two sentences.

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -77,8 +77,8 @@ class TestFileCabinet(fake_filesystem_unittest.TestCase):
     def test_create_plain_text(self):
         protocol, filename = 'file', 'tmp/sample.txt'
         content = "I am sample text!\nThis file has more than one line.\n" \
-                   "Hey look, a panda.\n\nその鶏のサイズを見てください\nNow it's a " \
-                   "new paragraph. This line has two sentences.\n🤯🦄\n"
+                  "Hey look, a panda.\n\nその鶏のサイズを見てください\nNow it's a " \
+                  "new paragraph. This line has two sentences.\n🤯🦄\n"
         cabinets.create(f'{protocol}://{filename}', content)
         with open(filename) as fh:
             data = fh.read()

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -70,15 +70,15 @@ class TestFileCabinet(fake_filesystem_unittest.TestCase):
         filename = os.path.join(self.fixture_path, 'sample.txt')
         data = cabinets.read(f'{protocol}://{filename}')
         expected = "I am sample text!\nThis file has more than one line.\n" \
-                   "Hey look, a panda.\n\nNow it's a new paragraph. This line has " \
-                   "two sentences.\n"
+                   "Hey look, a panda.\n\nその鶏のサイズを見てください\nNow it's a " \
+                   "new paragraph. This line has two sentences.\n🤯🦄\n"
         self.assertEqual(expected, data)
 
     def test_create_plain_text(self):
         protocol, filename = 'file', 'tmp/sample.txt'
         content = "I am sample text!\nThis file has more than one line.\n" \
-                  "Hey look, a panda.\n\nNow it's a new paragraph. This line has " \
-                  "two sentences.\n"
+                   "Hey look, a panda.\n\nその鶏のサイズを見てください\nNow it's a " \
+                   "new paragraph. This line has two sentences.\n🤯🦄\n"
         cabinets.create(f'{protocol}://{filename}', content)
         with open(filename) as fh:
             data = fh.read()

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -65,6 +65,25 @@ class TestFileCabinet(fake_filesystem_unittest.TestCase):
         result = cabinets.read(f'{protocol}://{filename}')
         self.assertDictEqual(data, result)
 
+    def test_read_plain_text(self):
+        protocol = 'file'
+        filename = os.path.join(self.fixture_path, 'sample.txt')
+        data = cabinets.read(f'{protocol}://{filename}')
+        expected = "I am sample text!\nThis file has more than one line.\n" \
+                   "Hey look, a panda.\n\nNow it's a new paragraph. This line has " \
+                   "two sentences.\n"
+        self.assertEqual(expected, data)
+
+    def test_create_plain_text(self):
+        protocol, filename = 'file', 'tmp/sample.txt'
+        content = "I am sample text!\nThis file has more than one line.\n" \
+                  "Hey look, a panda.\n\nNow it's a new paragraph. This line has " \
+                  "two sentences.\n"
+        cabinets.create(f'{protocol}://{filename}', content)
+        with open(filename) as fh:
+            data = fh.read()
+        self.assertEqual(content, data)
+
 
 @mock_s3
 class TestS3Cabinet(unittest.TestCase):


### PR DESCRIPTION
- Add parser for `txt` files
- `read()` just decodes content
- `create()` tries to cast the object as bytes and allows an `encoding` keyword argument