### PR TITLE
`parser` argument

### DIFF
--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -54,6 +54,12 @@ def from_uri(uri) -> (Cabinet, str):
 
 
 def set_configuration(protocol, **kwargs):
+    """
+    Set configuration parameters for a Cabinet
+
+    :param str protocol: Protocol identifier of Cabinet
+    :param dict kwargs: Configuration parameters to pass
+    """
     cabinet_cls = SUPPORTED_PROTOCOLS.get(protocol)
     if not cabinet_cls:
         raise CabinetError(f"Unsupported protocol: '{protocol}'")
@@ -87,9 +93,10 @@ def create(uri: str, content: Any, parser: Union[bool, Type[Parser]] = True, **k
         parsing using given parser
     :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
         methods
-    :return: None TODO: define standard return type
+    :return: None
     """
     cabinet_, path = from_uri(uri)
+    # TODO: define standard return type
     return cabinet_.create(path, content, parser=parser, **kwargs)
 
 

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -61,9 +61,9 @@ def set_configuration(protocol, **kwargs):
 
 def read(uri, parser=True, **kwargs):
     """
-    Read file content
+    Read file contents.
 
-    :param str path: Path to file
+    :param str path: Path to file including protocol identifier
     :param Union[bool, Type[Parser]] parser: `True` for parsing using default
         file extension Parser, `False` for no parsing, a `Parser` subclass for
         parsing using given parser
@@ -77,9 +77,9 @@ def read(uri, parser=True, **kwargs):
 
 def create(uri, content, parser=True, **kwargs):
     """
-    Create a file
+    Create a file.
 
-    :param str path: Path to file
+    :param str path: Path to file including protocol identifier
     :param Any content: Content to write
     :param Union[bool, Type[Parser]] parser: `True` for parsing using default
         file extension Parser, `False` for no parsing, a `Parser` subclass for
@@ -94,9 +94,9 @@ def create(uri, content, parser=True, **kwargs):
 
 def delete(uri, **kwargs):
     """
-    Delete a file
+    Delete a file.
 
-    :param str path: Path to file
+    :param str path: Path to file including protocol identifier
     :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
         methods
     """

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -67,8 +67,7 @@ def read(uri, parser=True, **kwargs):
     :param Union[bool, Type[Parser]] parser: `True` for parsing using default
         file extension Parser, `False` for no parsing, a `Parser` subclass for
         parsing using given parser
-    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser`
-    subclass
+    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
         methods
     :return Any: Parsed object read from file
     """
@@ -85,8 +84,7 @@ def create(uri, content, parser=True, **kwargs):
     :param Union[bool, Type[Parser]] parser: `True` for parsing using default
         file extension Parser, `False` for no parsing, a `Parser` subclass for
         parsing using given parser
-    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser`
-    subclass
+    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
         methods
     :return: None TODO: define standard return type
     """
@@ -99,8 +97,7 @@ def delete(uri, **kwargs):
     Delete a file
 
     :param str path: Path to file
-    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser`
-    subclass
+    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
         methods
     """
     cabinet_, path = from_uri(uri)

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -55,10 +55,10 @@ def from_uri(uri) -> (Cabinet, str):
 
 def set_configuration(protocol, **kwargs):
     """
-    Set configuration parameters for a Cabinet
+    Set configuration parameters for a Cabinet.
 
     :param str protocol: Protocol identifier of Cabinet
-    :param dict kwargs: Configuration parameters to pass
+    :param dict kwargs: Configuration parameters passed to delegate method
     """
     cabinet_cls = SUPPORTED_PROTOCOLS.get(protocol)
     if not cabinet_cls:

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -1,4 +1,5 @@
 import os
+from typing import Union, Type, Any
 
 from cabinets import plugins
 from cabinets.cabinet import (
@@ -59,11 +60,11 @@ def set_configuration(protocol, **kwargs):
     return cabinet_cls.set_configuration(**kwargs)
 
 
-def read(uri, parser=True, **kwargs):
+def read(uri: str, parser: Union[bool, Type[Parser]] = True, **kwargs):
     """
     Read file contents.
 
-    :param str path: Path to file including protocol identifier
+    :param str uri: Path to file including protocol identifier prefix (protocol://)
     :param Union[bool, Type[Parser]] parser: `True` for parsing using default
         file extension Parser, `False` for no parsing, a `Parser` subclass for
         parsing using given parser
@@ -75,11 +76,11 @@ def read(uri, parser=True, **kwargs):
     return cabinet_.read(path, parser=parser, **kwargs)
 
 
-def create(uri, content, parser=True, **kwargs):
+def create(uri: str, content: Any, parser: Union[bool, Type[Parser]] = True, **kwargs):
     """
     Create a file.
 
-    :param str path: Path to file including protocol identifier
+    :param str uri: Path to file including protocol identifier prefix (protocol://)
     :param Any content: Content to write
     :param Union[bool, Type[Parser]] parser: `True` for parsing using default
         file extension Parser, `False` for no parsing, a `Parser` subclass for
@@ -92,11 +93,11 @@ def create(uri, content, parser=True, **kwargs):
     return cabinet_.create(path, content, parser=parser, **kwargs)
 
 
-def delete(uri, **kwargs):
+def delete(uri: str, **kwargs):
     """
     Delete a file.
 
-    :param str path: Path to file including protocol identifier
+    :param str uri: Path to file including protocol identifier prefix (protocol://)
     :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
         methods
     """

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -59,14 +59,14 @@ def set_configuration(protocol, **kwargs):
     return cabinet_cls.set_configuration(**kwargs)
 
 
-def read(uri, raw=False, **kwargs):
+def read(uri, parser=True, **kwargs):
     cabinet_, path = from_uri(uri)
-    return cabinet_.read(path, raw=raw, **kwargs)
+    return cabinet_.read(path, parser=parser, **kwargs)
 
 
-def create(uri, content, raw=False, **kwargs):
+def create(uri, content, parser=True, **kwargs):
     cabinet_, path = from_uri(uri)
-    return cabinet_.create(path, content, raw=raw, **kwargs)
+    return cabinet_.create(path, content, parser=parser, **kwargs)
 
 
 def delete(uri, **kwargs):

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -60,15 +60,48 @@ def set_configuration(protocol, **kwargs):
 
 
 def read(uri, parser=True, **kwargs):
+    """
+    Read file content
+
+    :param str path: Path to file
+    :param Union[bool, Type[Parser]] parser: `True` for parsing using default
+        file extension Parser, `False` for no parsing, a `Parser` subclass for
+        parsing using given parser
+    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser`
+    subclass
+        methods
+    :return Any: Parsed object read from file
+    """
     cabinet_, path = from_uri(uri)
     return cabinet_.read(path, parser=parser, **kwargs)
 
 
 def create(uri, content, parser=True, **kwargs):
+    """
+    Create a file
+
+    :param str path: Path to file
+    :param Any content: Content to write
+    :param Union[bool, Type[Parser]] parser: `True` for parsing using default
+        file extension Parser, `False` for no parsing, a `Parser` subclass for
+        parsing using given parser
+    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser`
+    subclass
+        methods
+    :return: None TODO: define standard return type
+    """
     cabinet_, path = from_uri(uri)
     return cabinet_.create(path, content, parser=parser, **kwargs)
 
 
 def delete(uri, **kwargs):
+    """
+    Delete a file
+
+    :param str path: Path to file
+    :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser`
+    subclass
+        methods
+    """
     cabinet_, path = from_uri(uri)
-    return cabinet_.delete(path)
+    return cabinet_.delete(path, **kwargs)

--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABC, abstractmethod
 from typing import Union, Type
 
@@ -42,13 +43,10 @@ class Cabinet(ABC):
     def read(cls, path, parser: Union[bool, Type[Parser]] = True, **kwargs):
         if parser is True:
             return Parser.load(path, cls.read_content(path, **kwargs), **kwargs)
-        if parser is False:
+        elif parser is False:
             return cls.read_content(path, **kwargs)
-        try:
-            if issubclass(parser, Parser):
-                return parser.load_content(cls.read_content(path, **kwargs), **kwargs)
-        except TypeError:
-            pass
+        elif inspect.isclass(parser) and issubclass(parser, Parser):
+            return parser.load_content(cls.read_content(path, **kwargs), **kwargs)
 
         raise CabinetError(
             'Argument `parser` must be `True`, `False` or a `Parser` subclass')
@@ -59,11 +57,8 @@ class Cabinet(ABC):
             return cls.create_content(path, Parser.dump(path, content, **kwargs))
         if parser is False:
             return cls.create_content(path, content)
-        try:
-            if issubclass(parser, Parser):
-                return cls.create_content(path, parser.dump_content(content, **kwargs))
-        except TypeError:
-            pass
+        elif inspect.isclass(parser) and issubclass(parser, Parser):
+            return cls.create_content(path, parser.dump_content(content, **kwargs))
 
         raise CabinetError(
             'Argument `parser` must be `True`, `False` or a `Parser` subclass')

--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -55,7 +55,7 @@ class Cabinet(ABC):
     def create(cls, path, content, parser: Union[bool, Type[Parser]] = True, **kwargs):
         if parser is True:
             return cls.create_content(path, Parser.dump(path, content, **kwargs))
-        if parser is False:
+        elif parser is False:
             return cls.create_content(path, content)
         elif inspect.isclass(parser) and issubclass(parser, Parser):
             return cls.create_content(path, parser.dump_content(content, **kwargs))

--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -42,9 +42,9 @@ class Cabinet(ABC):
     @classmethod
     def read(cls, path: str, parser: Union[bool, Type[Parser]] = True, **kwargs) -> Any:
         """
-        Read file content
+        Read file contents using a specific protocol.
 
-        :param str path: Path to file
+        :param str path: Path to file within cabinet
         :param Union[bool, Type[Parser]] parser: `True` for parsing using default
             file extension Parser, `False` for no parsing, a `Parser` subclass for
             parsing using given parser
@@ -66,9 +66,9 @@ class Cabinet(ABC):
     def create(cls, path: str, content: Any, parser: Union[bool, Type[Parser]] = True,
                **kwargs):
         """
-        Create a file
+        Create a file using a specific protocol.
 
-        :param str path: Path to file
+        :param str path: Path to file within cabinet
         :param Any content: Content to write
         :param Union[bool, Type[Parser]] parser: `True` for parsing using default
             file extension Parser, `False` for no parsing, a `Parser` subclass for
@@ -90,9 +90,9 @@ class Cabinet(ABC):
     @classmethod
     def delete(cls, path: str, **kwargs):
         """
-        Delete a file
+        Delete a file using a specific protocol.
 
-        :param str path: Path to file
+        :param str path: Path to file within cabinet
         :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
             methods
         """

--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -93,7 +93,7 @@ class Cabinet(ABC):
             parsing using given parser
         :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
             methods
-        :return: None TODO: define standard return type
+        :return: None
         """
         cabinet_kwargs, parser_kwargs = _separate_kwargs(**kwargs)
         if parser is True:

--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -1,6 +1,6 @@
 import inspect
 from abc import ABC, abstractmethod
-from typing import Union, Type
+from typing import Union, Type, Any
 
 from cabinets.parser import Parser
 
@@ -40,7 +40,18 @@ class Cabinet(ABC):
         pass  # pragma: no cover
 
     @classmethod
-    def read(cls, path, parser: Union[bool, Type[Parser]] = True, **kwargs):
+    def read(cls, path: str, parser: Union[bool, Type[Parser]] = True, **kwargs) -> Any:
+        """
+        Read file content
+
+        :param str path: Path to file
+        :param Union[bool, Type[Parser]] parser: `True` for parsing using default
+            file extension Parser, `False` for no parsing, a `Parser` subclass for
+            parsing using given parser
+        :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
+            methods
+        :return Any: Parsed object read from file
+        """
         if parser is True:
             return Parser.load(path, cls.read_content(path, **kwargs), **kwargs)
         elif parser is False:
@@ -52,7 +63,20 @@ class Cabinet(ABC):
             'Argument `parser` must be `True`, `False` or a `Parser` subclass')
 
     @classmethod
-    def create(cls, path, content, parser: Union[bool, Type[Parser]] = True, **kwargs):
+    def create(cls, path: str, content: Any, parser: Union[bool, Type[Parser]] = True,
+               **kwargs):
+        """
+        Create a file
+
+        :param str path: Path to file
+        :param Any content: Content to write
+        :param Union[bool, Type[Parser]] parser: `True` for parsing using default
+            file extension Parser, `False` for no parsing, a `Parser` subclass for
+            parsing using given parser
+        :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
+            methods
+        :return: None TODO: define standard return type
+        """
         if parser is True:
             return cls.create_content(path, Parser.dump(path, content, **kwargs))
         elif parser is False:
@@ -64,7 +88,14 @@ class Cabinet(ABC):
             'Argument `parser` must be `True`, `False` or a `Parser` subclass')
 
     @classmethod
-    def delete(cls, path, **kwargs):
+    def delete(cls, path: str, **kwargs):
+        """
+        Delete a file
+
+        :param str path: Path to file
+        :param dict kwargs: Extra keyword arguments for `Cabinet` or `Parser` subclass
+            methods
+        """
         cls.delete_content(path, **kwargs)
 
     @classmethod

--- a/cabinets/cabinet/__init__.py
+++ b/cabinets/cabinet/__init__.py
@@ -51,7 +51,7 @@ class Cabinet(ABC):
             pass
 
         raise CabinetError(
-            'Argument `parser` must be True, False or a `Parser` subclass')
+            'Argument `parser` must be `True`, `False` or a `Parser` subclass')
 
     @classmethod
     def create(cls, path, content, parser: Union[bool, Type[Parser]] = True, **kwargs):
@@ -66,7 +66,7 @@ class Cabinet(ABC):
             pass
 
         raise CabinetError(
-            'Argument `parser` must be True, False or a `Parser` subclass')
+            'Argument `parser` must be `True`, `False` or a `Parser` subclass')
 
     @classmethod
     def delete(cls, path, **kwargs):

--- a/test/fixtures/sample_small.txt
+++ b/test/fixtures/sample_small.txt
@@ -1,0 +1,1 @@
+I am sample text!

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -83,11 +83,11 @@ class TestParserArgument(fake_filesystem_unittest.TestCase):
 
     def test_read_text_non_parser_custom_parser_raises(self):
         with self.assertRaises(cabinets.CabinetError):
-            cabinets.read('file://tmp/sample.txt', parser=str)
+            cabinets.read(os.path.join(self.fixture_path, 'sample.txt'), parser=str)
 
     def test_read_text_object_custom_parser_raises(self):
         with self.assertRaises(cabinets.CabinetError):
-            cabinets.read('file://tmp/sample.txt', parser=1)
+            cabinets.read(os.path.join(self.fixture_path, 'sample.txt'), parser=1)
 
     def test_create_text_non_parser_custom_parser_raises(self):
         with self.assertRaises(cabinets.CabinetError):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -80,3 +80,19 @@ class TestParserArgument(fake_filesystem_unittest.TestCase):
         with open(filename) as fh:
             data = json.load(fh)
         self.assertDictEqual({"hello": "world", "mock": "parser"}, data)
+
+    def test_read_text_non_parser_custom_parser_raises(self):
+        with self.assertRaises(cabinets.CabinetError):
+            cabinets.read('file://tmp/sample.txt', parser=str)
+
+    def test_read_text_object_custom_parser_raises(self):
+        with self.assertRaises(cabinets.CabinetError):
+            cabinets.read('file://tmp/sample.txt', parser=1)
+
+    def test_create_text_non_parser_custom_parser_raises(self):
+        with self.assertRaises(cabinets.CabinetError):
+            cabinets.create('file://tmp/sample.txt', "foo", parser=str)
+
+    def test_create_text_object_custom_parser_raises(self):
+        with self.assertRaises(cabinets.CabinetError):
+            cabinets.create('file://tmp/sample.txt', "foo", parser=1)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -81,18 +81,18 @@ class TestParserArgument(fake_filesystem_unittest.TestCase):
             data = json.load(fh)
         self.assertDictEqual({"hello": "world", "mock": "parser"}, data)
 
-    def test_read_text_non_parser_custom_parser_raises(self):
+    def test_read_text_custom_parser_raises(self):
         with self.assertRaises(cabinets.CabinetError):
             cabinets.read(os.path.join(self.fixture_path, 'sample.txt'), parser=str)
-
-    def test_read_text_object_custom_parser_raises(self):
         with self.assertRaises(cabinets.CabinetError):
             cabinets.read(os.path.join(self.fixture_path, 'sample.txt'), parser=1)
+        with self.assertRaises(cabinets.CabinetError):
+            cabinets.read(os.path.join(self.fixture_path, 'sample.txt'), parser=None)
 
-    def test_create_text_non_parser_custom_parser_raises(self):
+    def test_create_text_custom_parser_raises(self):
         with self.assertRaises(cabinets.CabinetError):
             cabinets.create('file://tmp/sample.txt', "foo", parser=str)
-
-    def test_create_text_object_custom_parser_raises(self):
         with self.assertRaises(cabinets.CabinetError):
             cabinets.create('file://tmp/sample.txt', "foo", parser=1)
+        with self.assertRaises(cabinets.CabinetError):
+            cabinets.create('file://tmp/sample.txt', "foo", parser=None)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -31,24 +31,24 @@ class TestParserArgument(fake_filesystem_unittest.TestCase):
         protocol = 'file'
         filename = os.path.join(self.fixture_path, 'sample_small.txt')
         data = cabinets.read(f'{protocol}://{filename}', parser=True)
-        expected = "I am sample text!"
         self.assertIsInstance(data, str)
+        expected = "I am sample text!"
         self.assertEqual(expected, data)
 
     def test_read_plain_text_no_parser(self):
         protocol = 'file'
         filename = os.path.join(self.fixture_path, 'sample_small.txt')
         data = cabinets.read(f'{protocol}://{filename}', parser=False)
-        expected = bytes("I am sample text!", encoding='utf-8')
         self.assertIsInstance(data, bytes)
+        expected = bytes("I am sample text!", encoding='utf-8')
         self.assertEqual(expected, data)
 
     def test_read_plain_text_custom_parser(self):
         protocol = 'file'
         filename = os.path.join(self.fixture_path, 'sample_small.txt')
         data = cabinets.read(f'{protocol}://{filename}', parser=MockTextParser)
-        expected = {'mock-parser': "I am sample text!"}
         self.assertIsInstance(data, dict)
+        expected = {'mock-parser': "I am sample text!"}
         self.assertDictEqual(expected, data)
 
     def test_create_json_default_parser(self):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -12,7 +12,7 @@ class MockTextParser(Parser):
         return {'mock-parser': content.decode('utf-8')}
 
 
-class TestFileCabinet(fake_filesystem_unittest.TestCase):
+class TestParserArgument(fake_filesystem_unittest.TestCase):
     fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 
     def setUp(self):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,0 +1,44 @@
+import os
+
+from pyfakefs import fake_filesystem_unittest
+
+import cabinets
+from cabinets import Parser
+
+
+class MockTextParser(Parser):
+    @classmethod
+    def load_content(cls, content: bytes, **kwargs):
+        return {'mock-parser': content.decode('utf-8')}
+
+
+class TestFileCabinet(fake_filesystem_unittest.TestCase):
+    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.fs.add_real_directory(self.fixture_path)
+
+    def test_read_plain_text_standard_parser(self):
+        protocol = 'file'
+        filename = os.path.join(self.fixture_path, 'sample_small.txt')
+        data = cabinets.read(f'{protocol}://{filename}', parser=True)
+        expected = "I am sample text!"
+        self.assertIsInstance(data, str)
+        self.assertEqual(expected, data)
+
+    def test_read_plain_text_no_parser(self):
+        protocol = 'file'
+        filename = os.path.join(self.fixture_path, 'sample_small.txt')
+        data = cabinets.read(f'{protocol}://{filename}', parser=False)
+        expected = bytes("I am sample text!", encoding='utf-8')
+        self.assertIsInstance(data, bytes)
+        self.assertEqual(expected, data)
+
+    def test_read_plain_text_custom_parser(self):
+        protocol = 'file'
+        filename = os.path.join(self.fixture_path, 'sample_small.txt')
+        data = cabinets.read(f'{protocol}://{filename}', parser=MockTextParser)
+        expected = {'mock-parser': "I am sample text!"}
+        self.assertIsInstance(data, dict)
+        self.assertDictEqual(expected, data)


### PR DESCRIPTION
Addresses https://github.com/lucasmlofaro/cabinets/issues/15

* Add `parser` argument for `read` and `create` 
  * Pass `True`  for default `Parser` class for extensions
  * Pass `False`  for no parsing
  * Pass a `Parser` subclass to parse with that class
* Pass all `kwargs` from `read` and `create` to `read_content` and `create_content` respectively (previously only were passed to `load_content` and `dump_content`)