### PR TITLE
Feature #42 - Remove `set_configuration()` / `region_name` requirement for `S3Cabinet` usage

### DIFF
--- a/cabinets/cabinet/s3_cabinet.py
+++ b/cabinets/cabinet/s3_cabinet.py
@@ -9,7 +9,7 @@ class S3Cabinet(Cabinet):
     client = None
 
     @classmethod
-    def set_configuration(cls, region_name='us-east-1', aws_access_key_id=None,
+    def set_configuration(cls, region_name=None, aws_access_key_id=None,
                           aws_secret_access_key=None, aws_session_token=None):
         cls.client = boto3.client('s3', region_name=region_name,
                                   aws_access_key_id=aws_access_key_id,
@@ -18,6 +18,9 @@ class S3Cabinet(Cabinet):
 
     @classmethod
     def read_content(cls, path, **kwargs) -> bytes:
+        if not cls.client:
+            cls.client = boto3.client('s3')
+
         bucket, *key = path.split('/')
         if not key:
             raise ValueError('S3 path needs bucket')
@@ -32,6 +35,9 @@ class S3Cabinet(Cabinet):
 
     @classmethod
     def create_content(cls, path, content, **kwargs):
+        if not cls.client:
+            cls.client = boto3.client('s3')
+
         bucket, *key = path.split('/')
         key = '/'.join(key)
         info(f"Uploading {key} to {bucket}")
@@ -44,6 +50,9 @@ class S3Cabinet(Cabinet):
 
     @classmethod
     def delete_content(cls, path, **kwargs):
+        if not cls.client:
+            cls.client = boto3.client('s3')
+
         bucket, *key = path.split('/')
         key = '/'.join(key)
         info(f"Deleting {key} from {bucket}")

--- a/cabinets/cabinet/s3_cabinet.py
+++ b/cabinets/cabinet/s3_cabinet.py
@@ -9,6 +9,11 @@ class S3Cabinet(Cabinet):
     client = None
 
     @classmethod
+    def _ensure_client_exists(cls):
+        if not cls.client:
+            cls.client = boto3.client('s3')
+
+    @classmethod
     def set_configuration(cls, region_name=None, aws_access_key_id=None,
                           aws_secret_access_key=None, aws_session_token=None):
         cls.client = boto3.client('s3', region_name=region_name,
@@ -18,8 +23,7 @@ class S3Cabinet(Cabinet):
 
     @classmethod
     def read_content(cls, path, **kwargs) -> bytes:
-        if not cls.client:
-            cls.client = boto3.client('s3')
+        cls._ensure_client_exists()
 
         bucket, *key = path.split('/')
         if not key:
@@ -35,8 +39,7 @@ class S3Cabinet(Cabinet):
 
     @classmethod
     def create_content(cls, path, content, **kwargs):
-        if not cls.client:
-            cls.client = boto3.client('s3')
+        cls._ensure_client_exists()
 
         bucket, *key = path.split('/')
         key = '/'.join(key)
@@ -50,8 +53,7 @@ class S3Cabinet(Cabinet):
 
     @classmethod
     def delete_content(cls, path, **kwargs):
-        if not cls.client:
-            cls.client = boto3.client('s3')
+        cls._ensure_client_exists()
 
         bucket, *key = path.split('/')
         key = '/'.join(key)

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -118,6 +118,10 @@ class TestTopLevelConfiguration(unittest.TestCase):
             cabinets.set_configuration('s4', region_name='us-west-2')
 
 
+@patch.dict(os.environ, {'AWS_ACCESS_KEY_ID': 'testing',
+                         'AWS_SECRET_ACCESS_KEY': 'testing',
+                         'AWS_SECURITY_TOKEN': 'testing',
+                         'AWS_SESSION_TOKEN': 'testing', })
 @mock_s3
 class TestS3CabinetNoRegion(unittest.TestCase):
 
@@ -179,6 +183,10 @@ class TestS3CabinetNoRegion(unittest.TestCase):
         client.delete_bucket(Bucket=bucket)
 
 
+@patch.dict(os.environ, {'AWS_ACCESS_KEY_ID': 'testing',
+                         'AWS_SECRET_ACCESS_KEY': 'testing',
+                         'AWS_SECURITY_TOKEN': 'testing',
+                         'AWS_SESSION_TOKEN': 'testing', })
 @mock_s3
 class TestS3CabinetWithRegion(unittest.TestCase):
 

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -118,11 +118,11 @@ class TestTopLevelConfiguration(unittest.TestCase):
             cabinets.set_configuration('s4', region_name='us-west-2')
 
 
+@mock_s3
 @patch.dict(os.environ, {'AWS_ACCESS_KEY_ID': 'testing',
                          'AWS_SECRET_ACCESS_KEY': 'testing',
                          'AWS_SECURITY_TOKEN': 'testing',
                          'AWS_SESSION_TOKEN': 'testing', })
-@mock_s3
 class TestS3CabinetNoRegion(unittest.TestCase):
 
     def test_set_configuration_region(self):
@@ -183,11 +183,11 @@ class TestS3CabinetNoRegion(unittest.TestCase):
         client.delete_bucket(Bucket=bucket)
 
 
+@mock_s3
 @patch.dict(os.environ, {'AWS_ACCESS_KEY_ID': 'testing',
                          'AWS_SECRET_ACCESS_KEY': 'testing',
                          'AWS_SECURITY_TOKEN': 'testing',
                          'AWS_SESSION_TOKEN': 'testing', })
-@mock_s3
 class TestS3CabinetWithRegion(unittest.TestCase):
 
     def setUp(self) -> None:

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -152,21 +152,6 @@ class TestS3CabinetNoRegion(unittest.TestCase):
         self.assertDictEqual(data, result)
         client.delete_bucket(Bucket=bucket)
 
-    def test_read_create_with_default_region(self):
-        client = boto3.client('s3', 'us-east-2')
-        bucket = 'mock-bucket'
-        client.create_bucket(
-            Bucket=bucket,
-            CreateBucketConfiguration={'LocationConstraint': 'us-east-2'}
-        )
-        protocol, filename = 's3', f'{bucket}/test.yml'
-        data = {'I': {'am': ['nested', 1, 'object', None]}}
-        cabinets.create(f'{protocol}://{filename}', data)
-        result = cabinets.read(f'{protocol}://{filename}')
-        cabinets.delete(f'{protocol}://{filename}')
-        self.assertDictEqual(data, result)
-        client.delete_bucket(Bucket=bucket)
-
     def test_read_create_with_different_region(self):
         client = boto3.client('s3', 'us-east-2')
         bucket = 'mock-bucket'

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import boto3
 from moto import mock_s3
@@ -117,6 +118,7 @@ class TestTopLevelConfiguration(unittest.TestCase):
             cabinets.set_configuration('s4', region_name='us-west-2')
 
 
+@patch.dict(os.environ, {}, clear=True)
 @mock_s3
 class TestS3CabinetNoRegion(unittest.TestCase):
 
@@ -180,6 +182,7 @@ class TestS3CabinetNoRegion(unittest.TestCase):
         client.delete_bucket(Bucket=bucket)
 
 
+@patch.dict(os.environ, {}, clear=True)
 @mock_s3
 class TestS3CabinetWithRegion(unittest.TestCase):
 

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -118,14 +118,11 @@ class TestTopLevelConfiguration(unittest.TestCase):
             cabinets.set_configuration('s4', region_name='us-west-2')
 
 
-@patch.dict(os.environ, {}, clear=True)
 @mock_s3
 class TestS3CabinetNoRegion(unittest.TestCase):
 
     def test_set_configuration_region(self):
         self.assertIsNotNone(S3Cabinet.client)
-        # default AWS region is us-east-1
-        self.assertEqual(S3Cabinet.client.meta.region_name, 'us-east-1')
 
     def test_read_create_s3_cabinet(self):
         client = boto3.client('s3')
@@ -182,7 +179,6 @@ class TestS3CabinetNoRegion(unittest.TestCase):
         client.delete_bucket(Bucket=bucket)
 
 
-@patch.dict(os.environ, {}, clear=True)
 @mock_s3
 class TestS3CabinetWithRegion(unittest.TestCase):
 


### PR DESCRIPTION
Addresses https://github.com/lucasmlofaro/cabinets/issues/42
Addresses https://github.com/lucasmlofaro/cabinets/issues/21

Notes:
* If the `boto3.client('s3')` instance is instantiated at class creation time, it will not be properly mocked by the `moto` library, thus the decision to instantiate it on function call if not found. 