### PR TITLE
Improve protocol parsing

### DIFF
--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -57,11 +57,15 @@ def from_uri(uri: Union[str, Path]) -> (Cabinet, str):
         except AttributeError:
             uri = uri.as_uri()
 
-    try:
-        protocol, path = uri.split('://')
-    except ValueError:
+    parts = uri.split('://')
+    if len(parts) < 2:
         debug("No cabinet protocol identifier specified: using 'file'")
         protocol, path = 'file', uri
+    elif len(parts) > 2:
+        raise InvalidURIError("Must specify a single protocol separator '://'")
+    else:
+        protocol, path = parts
+
     cabinet_ = SUPPORTED_PROTOCOLS.get(protocol)
     if not cabinet_:
         raise InvalidURIError(f"Unknown protocol '{protocol}'")

--- a/cabinets/__init__.py
+++ b/cabinets/__init__.py
@@ -40,12 +40,12 @@ class InvalidURIError(Exception):
     pass
 
 
-def from_uri(uri: Union[str, Path]) -> (Cabinet, str):
+def _parse_protocol(uri: Union[str, Path]) -> (Cabinet, str):
     """Separate a URI string or Path object into a protocol and path
 
     :param Union[str, Path] uri: String URI or Path object representing a file
-    :return: Cabinet class to use and path at which to find file using the Cabinet
-    :rtype: (Cabinet, str)
+    :return: Protocol to use for reading the file and its associated path
+    :rtype: (str, str)
     """
     if isinstance(uri, PurePath):
         # only standard Path objects have `resolve()`, however checking for
@@ -65,6 +65,18 @@ def from_uri(uri: Union[str, Path]) -> (Cabinet, str):
         raise InvalidURIError("Must specify a single protocol separator '://'")
     else:
         protocol, path = parts
+
+    return protocol, path
+
+
+def from_uri(uri: Union[str, Path]) -> (Cabinet, str):
+    """Creates a Cabinet instance from a URI or Path
+
+    :param Union[str, Path] uri: String URI or Path object representing a file
+    :return: Cabinet class to use and path at which to find file using the Cabinet
+    :rtype: (Cabinet, str)
+    """
+    protocol, path = _parse_protocol(uri)
 
     cabinet_ = SUPPORTED_PROTOCOLS.get(protocol)
     if not cabinet_:

--- a/test/test_cabinet.py
+++ b/test/test_cabinet.py
@@ -295,6 +295,11 @@ class TestURI(unittest.TestCase):
         with self.assertRaises(InvalidURIError):
             cabinets.from_uri(uri)
 
+    def test_cabinet_from_uri_fails_on_multiple_protocol_separators(self):
+        uri = 'file://path/to/file://path/to/another/file'
+        with self.assertRaises(InvalidURIError):
+            cabinets.from_uri(uri)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #40 

- Ensure only a single protocol separator is present `://`
- Raise an `InvalidURIError` if multiple protocol separators are present
- Keep behavior of defaulting to `file` protocol if none is specified